### PR TITLE
#169385153 add slugs to accommodations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7463,6 +7463,11 @@
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
+    "slugify": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.5.tgz",
+      "integrity": "sha512-5VCnH7aS13b0UqWOs7Ef3E5rkhFe8Od+cp7wybFv5mv/sYSRkucZlJX0bamAJky7b2TTtGvrJBWVdpdEicsSrA=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "request": "^2.87.0",
     "sequelize": "^5.19.1",
     "sequelize-cli": "^5.5.1",
+    "slugify": "^1.3.5",
     "swagger-jsdoc": "^3.4.0",
     "swagger-ui-express": "^4.1.1",
     "underscore": "^1.9.1"

--- a/src/controllers/accommodationController.js
+++ b/src/controllers/accommodationController.js
@@ -1,4 +1,5 @@
 import cloudinary from 'cloudinary';
+import slugify from 'slugify';
 import models from '../database/models';
 import strings from '../utils/stringsUtil';
 import responseUtil from '../utils/responseUtil';
@@ -29,7 +30,8 @@ export default class AccommodationController {
       highlights,
       amenities,
       owner: req.user.payload.id,
-      images
+      images,
+      slug: slugify(name.toLowerCase())
     };
     try {
       const newAccommodation = await models.accommodations.create(accommodation);

--- a/src/database/migrations/20190930143254-User.js
+++ b/src/database/migrations/20190930143254-User.js
@@ -27,7 +27,7 @@ module.exports = {
       allowNull: true
     },
     dob: {
-      type: Sequelize.DATE,
+      type: Sequelize.DATEONLY,
       allowNull: true
     },
     country: {
@@ -69,8 +69,8 @@ module.exports = {
         }
       }
     },
-    createdAt: Sequelize.DATE,
-    updatedAt: Sequelize.DATE,
+    createdAt: Sequelize.DATEONLY,
+    updatedAt: Sequelize.DATEONLY,
   }),
   down: queryInterface => queryInterface.dropTable('users')
 };

--- a/src/database/migrations/20191015081823-create-trip-types.js
+++ b/src/database/migrations/20191015081823-create-trip-types.js
@@ -13,11 +13,11 @@ module.exports = {
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       }
     });
   },

--- a/src/database/migrations/20191015081900-create-request-status.js
+++ b/src/database/migrations/20191015081900-create-request-status.js
@@ -13,11 +13,11 @@ module.exports = {
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       }
     });
   },

--- a/src/database/migrations/20191015082308-create-destinations.js
+++ b/src/database/migrations/20191015082308-create-destinations.js
@@ -31,11 +31,11 @@ module.exports = {
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       }
     });
   },

--- a/src/database/migrations/20191015091939-create-locations.js
+++ b/src/database/migrations/20191015091939-create-locations.js
@@ -17,11 +17,11 @@ module.exports = {
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       }
     });
   },

--- a/src/database/migrations/20191016090432-create-role.js
+++ b/src/database/migrations/20191016090432-create-role.js
@@ -16,11 +16,11 @@ module.exports = {
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATEONLY
       }
     });
   },

--- a/src/database/migrations/20191017165632-create-accommodations.js
+++ b/src/database/migrations/20191017165632-create-accommodations.js
@@ -23,6 +23,7 @@ module.exports = {
       amenities: { type: Sequelize.STRING},
       owner: {type: Sequelize.INTEGER},
       images: {type: Sequelize.JSONB},
+      slug: {type: Sequelize.STRING},
       createdAt: {allowNull: false,type: Sequelize.DATEONLY},
       updatedAt: {allowNull: false,type: Sequelize.DATEONLY}
     });

--- a/src/database/models/accommodations.js
+++ b/src/database/models/accommodations.js
@@ -9,7 +9,8 @@ module.exports = (sequelize, DataTypes) => {
     highlights: DataTypes.STRING,
     amenities: DataTypes.STRING,
     owner: DataTypes.INTEGER,
-    images: DataTypes.JSONB
+    images: DataTypes.JSONB,
+    slug: DataTypes.STRING,
   }, { tableName: 'accommodations' });
   accommodations.associate = models => {
     // associations can be defined here

--- a/src/database/models/destinations.js
+++ b/src/database/models/destinations.js
@@ -3,8 +3,8 @@ module.exports = (sequelize, DataTypes) => {
   const destinations = sequelize.define('destinations', {
     locationId: DataTypes.INTEGER,
     bookingId: DataTypes.INTEGER,
-    arrivalDate: DataTypes.DATE,
-    departureDate: DataTypes.DATE,
+    arrivalDate: DataTypes.DATEONLY,
+    departureDate: DataTypes.DATEONLY,
     requestId: DataTypes.INTEGER,
     reasons: DataTypes.STRING,
     isFinal: DataTypes.BOOLEAN

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, Datatypes) => {
     role: Datatypes.INTEGER,
     phone: Datatypes.STRING,
     gender: Datatypes.STRING,
-    dob: Datatypes.DATE,
+    dob: Datatypes.DATEONLY,
     country: Datatypes.STRING,
     language: Datatypes.STRING,
     currency: Datatypes.STRING,


### PR DESCRIPTION
#### What does this PR do?
Generate slugs for new  accommodations

#### Description of Task to be completed?
- Add a slug upon accommodation creation
- Format dates to a more readable format

#### How should this be manually tested?
- Clone the repository from [here](https://github.com/andela/caret-bn-backend.git)
- Browse to the repo directory
- navigate to bg-slugify-accommodations-169385153 branch
- Run `npm install`
- run `sequelize db:migrate`
- run `sequelize db:seed:all`
- run `npm run dev`
 **To add a new accommodation**
- In Postman Provide a login bearer token
- Fill the body with all necessary fields and select image file(s)
- send a `POST` request to `http://localhost:<:port>/api/v1/accommodations`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#169385153
](https://www.pivotaltracker.com/story/show/169385153)

#### Screenshots (if appropriate)
<img width="766" alt="Screen Shot 2019-10-27 at 19 50 49" src="https://user-images.githubusercontent.com/50104386/67639001-75e20980-f8f3-11e9-9788-9d5cb4e42334.png">

#### Questions:
N/A
