### PR TITLE
#168781692 add and view comment

### DIFF
--- a/src/controllers/commentsController.js
+++ b/src/controllers/commentsController.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-irregular-whitespace */
+import Sequelize from 'sequelize';
+import models from '../database/models';
+import responseUtil from '../utils/responseUtil';
+import strings from '../utils/stringsUtil';
+
+export default class CommentsController {
+
+  static async addComment(req, res) {
+    const { comment } = req.body;
+    const { id } = req.user.payload;
+    const requestId = parseInt(req.params.id, 10);
+
+    try {
+      const newComment = { comment, userId: id, requestId };
+      const addedComment = await models.comments.create(newComment);
+      const {
+        deleted, createdAt, updatedAt, userId,
+        ...data
+      } = addedComment.dataValues;
+
+      return responseUtil(res, 200, strings.request.success.SUCCESS_ADD_COMMENT, data);
+    } catch (error) {
+      return res.status(500).json({ error: 'Something wrong' });
+    }
+  }
+
+  static async getComments(req, res) {
+    try {
+      const requestId = parseInt(req.params.id, 10);
+      const { Op } = Sequelize;
+      const comments = await models.comments.findAll({
+        attributes: { exclude: ['userId', 'createdAt', 'updatedAt'] },
+        include: [{ association: 'user', attributes: ['id', 'username', 'email'] }],
+        where: {
+          [Op.and]: [{ requestId },
+            { deleted: false }]
+        },
+      });
+      if (!comments.length) return responseUtil(res, 404, 'no comment exist');
+
+      return responseUtil(res, 200, 'request comments', comments);
+
+    } catch (error) {
+      return res.status(500).json({ error: 'Something wrong' });
+    }
+  }
+}

--- a/src/database/migrations/20191029094504-create-comments.js
+++ b/src/database/migrations/20191029094504-create-comments.js
@@ -18,7 +18,8 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       deleted: {
-        type: Sequelize.BOOLEAN
+        type: Sequelize.BOOLEAN,
+        defaultValue: false
       },
       createdAt: {
         allowNull: false,

--- a/src/database/models/comments.js
+++ b/src/database/models/comments.js
@@ -1,24 +1,24 @@
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const comments = sequelize.define('comments', {
-    comment: DataTypes.STRING,
-    userId: DataTypes.INTEGER,
-    requestId: DataTypes.INTEGER,
-    deleted: {
-      type: DataTypes.BOOLEAN,
-      defaultValue: false
-    }
-  }, {});
+    comment: { type:DataTypes.STRING, allowNull: false} ,
+    userId: { type:DataTypes.INTEGER},
+    requestId: { type:DataTypes.INTEGER },
+    deleted: {type:DataTypes.BOOLEAN, defaultValue:false} ,
+  }, { freezeTableName: true });
+  
   comments.associate = function(models) {
-    // associations can be defined here
     comments.belongsTo(models.users, {
-      as: 'commenter',
-      foreignKey: 'userId',
-    });
+        as: 'user',
+        foreignKey: 'userId',
+        targetKey: 'id',
+      });
     comments.belongsTo(models.requests, {
-      as: 'requestComment',
-      foreignKey: 'requestId',
-    });
+        as: 'request',
+        foreignKey: 'requestId',
+        targetKey: 'id',
+      });
+
   };
   return comments;
 };

--- a/src/database/seeders/20191030145443-comments.js
+++ b/src/database/seeders/20191030145443-comments.js
@@ -1,0 +1,18 @@
+'use strict';
+module.exports = {
+ up: (queryInterface, Sequelize) => Promise.all([
+   queryInterface.bulkInsert('comments', [
+     {
+       comment: 'i want to go to andela kigali',
+       userId: 3,
+       requestId: 3,
+       deleted: false,
+       createdAt: new Date(),
+       updatedAt: new Date()
+     }
+ ])
+ ]),
+ down: (queryInterface, Sequelize) => Promise.all([
+   queryInterface.bulkDelete('comments', null, {})
+ ])
+};

--- a/src/middlewares/commentMiddleware.js
+++ b/src/middlewares/commentMiddleware.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-irregular-whitespace */
+import responseError from '../utils/responseError';
+import string from '../utils/stringsUtil';
+import models from '../database/models';
+
+const { requests, users } = models;
+
+const comments = {
+  async checkOwner(req, res, next) {
+    const loggedUserId = req.user.payload.id;
+    const id = parseInt(req.params.id, 10);
+
+    const requester = await requests.findOne({ where: { id }, include: [{ model: users }] });
+    if ((requester.userId === loggedUserId) || (requester.user.lineManager === loggedUserId)) {
+      return next();
+    }
+    return responseError(res, 400, string.request.error.NOT_YOUR_REQUEST);
+  },
+
+  async checkExistingRequest(req, res, next) {
+    const requestId = parseInt(req.params.id, 10);
+    const request = await requests.findOne({
+      where: { id: requestId }
+    });
+    if (request) {
+      req.request = request;
+      return next();
+    }
+    return responseError(res, 400, string.request.error.NO_REQUEST_REQUEST);
+  }
+};
+export default comments;

--- a/src/middlewares/inputValidation.js
+++ b/src/middlewares/inputValidation.js
@@ -200,4 +200,11 @@ export default class InputValidation {
     });
     validation(req, res, schema, next);
   }
+
+  static validateComment(req, res, next) {
+    const schema = Joi.object({
+      comment: Joi.string().required(),
+    });
+    validation(req, res, schema, next);
+  }
 }

--- a/src/routes/api/comments.js
+++ b/src/routes/api/comments.js
@@ -1,0 +1,73 @@
+import { Router } from 'express';
+import commentsController from '../../controllers/commentsController';
+import validateToken from '../../middlewares/auth/validateToken';
+import InputValidation from '../../middlewares/inputValidation';
+import comments from '../../middlewares/commentMiddleware';
+
+const router = new Router();
+const { addComment, getComments } = commentsController;
+const { validateComment } = InputValidation;
+const { checkExistingRequest, checkOwner } = comments;
+
+/**
+ * @swagger
+ * definitions:
+ *   createComments:
+ *     type: object
+ *     properties:
+ *       name:
+ *         comment: string
+ *         example: hey
+ */
+/**
+ * @swagger
+ * /comments/{id}:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Comments
+ *     name: Create a Comment
+ *     summary: Create a Comment
+ *     consumes:
+ *       - application/json
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: body
+ *         in: body
+ *         schema:
+ *          $ref: '#/definitions/createComments'
+ *       - name: id
+ *         in: path
+ *         schema:
+ *          type: integer
+ *     responses:
+ *       '201':
+ *         description: New comment added successfully!
+*/
+/**
+ * @swagger
+ * /comments/{id}:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Comments
+ *     name: Get all comments
+ *     summary: Get all comments
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         schema:
+ *          type: integer
+ *     responses:
+ *       '200':
+ *         description: Comments retrieved successfully!!
+*/
+
+router.post('/:id', validateToken, validateComment, checkExistingRequest, checkOwner, addComment);
+router.get('/:id', validateToken, checkExistingRequest, checkOwner, getComments);
+export default router;

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -5,6 +5,7 @@ import authRoutes from './auth/index';
 import requestRoutes from './requests';
 import accommodationsRoutes from './accommodations';
 import notificationsRoutes from './notifications';
+import comments from './comments';
 import swaggerRoute from '../swagger-doc';
 import ratingRoutes from './ratings';
 
@@ -16,6 +17,7 @@ router.use('/users', usersRoutes);
 router.use('/accommodations', accommodationsRoutes);
 router.use('/notifications', notificationsRoutes);
 router.use('/ratings', ratingRoutes);
+router.use('/comments', comments);
 router.use('/api-docs', swaggerRoute);
 
 export default router;

--- a/src/tests/comment.spec.js
+++ b/src/tests/comment.spec.js
@@ -1,0 +1,79 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { describe, it, before } from 'mocha';
+import app from '../index';
+import mockdata from './mockData/mockData';
+import generateToken from '../utils/generateToken';
+
+const token = generateToken(mockdata.verifiedUser1);
+const token2 = generateToken(mockdata.requester);
+const token3 = generateToken(mockdata.verifiedUser);
+
+chai.should();
+chai.use(chaiHttp);
+
+const id = mockdata.verifiedUser1.id;
+
+const newRequest = {
+    comment:'dsknfkjsnfkdsnkl'
+}
+
+describe('comment tests', () =>{
+    it('should add new comment', (done) => {
+      chai.request(app)  
+      .post('/api/v1/comments/2')
+      .set('Authorization', `Bearer ${token}`)
+      .send(newRequest)
+      .end((err, res) => {
+          res.should.have.property('status').eql(200);
+      done();
+      });
+  });
+  it('should get all comment ', (done) => {
+    chai.request(app)  
+    .get('/api/v1/comments/2')
+    .set('Authorization', `Bearer ${token}`)
+    .end((err, res) => {
+        res.should.have.property('status').eql(200);
+    done();
+    });
+});
+it('should return a 400 when you are not owner of the request or manager', (done) => {
+    chai.request(app)  
+    .get('/api/v1/comments/2')
+    .set('Authorization', `Bearer ${token3}`)
+    .end((err, res) => {
+        console.log(res.body);
+        
+        res.should.have.property('status').eql(400);
+    done();
+    });
+});
+it('should get 400 when there is no data in the body ', (done) => {
+    chai.request(app)  
+    .post('/api/v1/comments/3')
+    .set('Authorization', `Bearer ${token}`)
+    .end((err, res) => {
+        res.should.have.property('status').eql(400);
+    done();
+    });
+});
+it('should get 400 when there is no data in the body ', (done) => {
+    chai.request(app)  
+    .post('/api/v1/comments/333')
+    .set('Authorization', `Bearer ${token}`)
+    .end((err, res) => {
+        res.should.have.property('status').eql(400);
+    done();
+    });
+});
+it('should get 400 when there is no data in the body ', (done) => {
+    chai.request(app)  
+    .get('/api/v1/comments/3')
+    .set('Authorization', `Bearer ${token3}`)
+    .end((err, res) => {
+        res.should.have.property('status').eql(400);
+    done();
+    });
+});
+});

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -12,6 +12,7 @@ import adminTest from './adminTest.spec';
 import searchRequestsTests from './searchRequestsTests.spec';
 import notificationsTests from './notificationsTests.spec';
 import ratingsTest from './ratingsTests.spec';
+import commentsTests from './comment.spec';
 
 describe('Default Tests', defaultTests);
 describe('Edit Request Tests', editRequest);
@@ -31,3 +32,5 @@ describe('Admin routes test', adminTest);
 describe('Search Requests Tests', searchRequestsTests);
 describe('Notifications Tests', notificationsTests);
 describe('Ratings Tests', ratingsTest);
+describe('Comments Tests', commentsTests);
+

--- a/src/tests/mockData/mockData.js
+++ b/src/tests/mockData/mockData.js
@@ -1,6 +1,7 @@
 const mockData = {
   verifiedUser: { email: 'user@caretbn.com', password: 'Pa55w0rd' },
   verifiedUser1: { id: 3, email: 'ghost@caretbn.com', password: 'Pa55w0rd' },
+  verifiedUser3: { id: 100, email: 'ghos@caretbn.com', password: 'Pa55w0rd' },
   registeredUser: { email: 'ghost@caretbn.com', password: 'Pa55w0rd' },
   unVerifiedUser: { email: 'johndoe@test.com', password: 'Pa55w0rd' },
   invalidData: { email: 'email@email.com', password: 'password' },

--- a/src/utils/stringsUtil.js
+++ b/src/utils/stringsUtil.js
@@ -44,14 +44,18 @@ const strings = {
   request: {
     success: {
       SUCCESS_UPDATE_REQUEST: 'Request Updated',
+      SUCCESS_ADD_COMMENT: 'Comment Added',
     },
     error: {
       INTERNAL_ERROR: 'Internal server error',
+      NO_REQUEST_REQUEST: 'This Id request does not exist',
       EDIT_YOUR_REQUEST: 'Access denied! you are not the owner of this request',
       NO_REQUEST: 'Access denied! You have no request to edit',
       NO_ACCESS: 'Access denied! Only system administrators and pre-screened suppliers can access this part of the system!',
       SUPPLIER_NOT_ALLOWED: 'Access denied! Suppliers can not access this part of the system!',
       NOT_ALLOWED: 'Access denied! a supplier can not access this part of the system!',
+      TRAVEL_ADMINS_ONLY: 'Access denied! Only travel administrators can access this part of the system!',
+      NOT_YOUR_REQUEST: 'You are not the owner of the request or the line manager of the user who placed it!',
     },
   },
   token: {


### PR DESCRIPTION

#### What does this PR do?
- Add and view comments 
#### Description of Task to be completed?
- add the possibility for line manager and owner of the request to add a comment on the request
- add the possibility for line manager and owner of the request to view a comment on the request
#### How should this be manually tested?
- Browse to the repo directory
- navigate to Ft-comment-168781692 branch
- Run `npm install`
- run `sequelize db:migrate`
- run `sequelize db:seed:all`
- run `npm run dev`
#### Any background context you want to provide?
**To add a comment**
- In Postman Provide a login bearer token
- Fill the body with comment field
- send a `POST` request to `http://localhost:<:port>/api/v1/comments/:id`

**To view a comment**
- In Postman Provide a login bearer token
- send a `GET` request to `http://localhost:<:port>/api/v1/comments/:id`
#### What are the relevant pivotal tracker stories?
[#168781692](https://www.pivotaltracker.com/story/show/168781692)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/38130305/67929988-64d11b00-fbc7-11e9-83dd-42cba00a8232.png)

#### Questions:
N/A