### PR TITLE
#169469778 - Modify Search Fonctionality

### DIFF
--- a/src/database/migrations/20191103171511-addFirstLastName.js
+++ b/src/database/migrations/20191103171511-addFirstLastName.js
@@ -1,0 +1,17 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(t => Promise.all([
+    queryInterface.addColumn('users', 'firstName', {
+      type: Sequelize.STRING,
+      allowNull: true
+    }, { transaction: t }),
+    queryInterface.addColumn('users', 'lastName', {
+      type: Sequelize.STRING,
+      allowNull: true
+    }, { transaction: t }),
+  ])),
+
+  down: queryInterface => queryInterface.sequelize.transaction(t => Promise.all([
+    queryInterface.removeColumn('users', 'firstName', { transaction: t }),
+    queryInterface.removeColumn('users', 'lastName', { transaction: t }),
+  ])),
+};

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -2,6 +2,8 @@ module.exports = (sequelize, Datatypes) => {
   const Users = sequelize.define('users', {
     username: Datatypes.STRING,
     email: Datatypes.STRING,
+    firstName: Datatypes.STRING,
+    lastName: Datatypes.STRING,
     googleId: Datatypes.STRING,
     facebookId: Datatypes.STRING,
     password: Datatypes.STRING,

--- a/src/helpers/findLocation.js
+++ b/src/helpers/findLocation.js
@@ -1,0 +1,10 @@
+import models from '../database/models';
+
+const findLocation = async option => {
+  const locations = await models.locations.findAll({
+    where: option,
+  });
+  return locations;
+};
+
+export default findLocation;

--- a/src/middlewares/catchOriginDestination.js
+++ b/src/middlewares/catchOriginDestination.js
@@ -1,0 +1,23 @@
+import { Op } from 'sequelize';
+import findLocation from '../helpers/findLocation';
+
+const catchProperty = async (req, property) => {
+  if (Object.keys(req.body).includes(property)) {
+    const array = [];
+    const locations = await findLocation({ name: { [Op.iLike]: `%${req.body[property]}%` }, });
+
+    locations.forEach(location => {
+      array.push(location.id);
+    });
+
+    req.body[property] = array;
+  }
+};
+
+const catchOriginDestination = async (req, res, next) => {
+  await catchProperty(req, 'origin');
+  await catchProperty(req, 'destination');
+  return next();
+};
+
+export default catchOriginDestination;

--- a/src/middlewares/inputValidation.js
+++ b/src/middlewares/inputValidation.js
@@ -116,10 +116,8 @@ export default class InputValidation {
   static validateSearchRequestUser(req, res, next) {
     const schema = Joi.object({
       id: Joi.number().integer().min(1),
-      destination: Joi.number().integer().min(1)
-        .message('Enter the id of the location'),
-      origin: Joi.number().integer().min(1)
-        .message('Enter the id of the location'),
+      destination: Joi.string().trim().min(3),
+      origin: Joi.string().trim().min(3),
       duration: Joi.number().integer().min(1),
       departureDate: Joi.string()
         .regex(/^\d{4}(-)(((0)[0-9])|((1)[0-2]))(-)([0-2][0-9]|(3)[0-1])$/)
@@ -134,11 +132,9 @@ export default class InputValidation {
   static validateSearchRequestManager(req, res, next) {
     const schema = Joi.object({
       id: Joi.number().integer().min(1),
-      userId: Joi.number().integer().min(1),
-      destination: Joi.number().integer().min(1)
-        .message('Enter the id of the location'),
-      origin: Joi.number().integer().min(1)
-        .message('Enter the id of the location'),
+      username: Joi.string().trim().min(3),
+      destination: Joi.string().trim().min(3),
+      origin: Joi.string().trim().min(3),
       duration: Joi.number().integer().min(1),
       departureDate: Joi.string()
         .regex(/^\d{4}(-)(((0)[0-9])|((1)[0-2]))(-)([0-2][0-9]|(3)[0-1])$/)

--- a/src/routes/api/requests.js
+++ b/src/routes/api/requests.js
@@ -12,6 +12,7 @@ import catchSearchQueries from '../../middlewares/catchSearchQueries';
 import pendingRequest from '../../middlewares/request';
 import isProcessed from '../../middlewares/isProcessed';
 import wrongAction from '../../middlewares/wrongAction';
+import catchOriginDestination from '../../middlewares/catchOriginDestination';
 
 const router = new Router();
 const {
@@ -148,7 +149,7 @@ router.use(validateToken);
 router.post('/', verifyRelationships, (req, res) => requestController.storeRequest(req, res));
 router.get('/search', validateToken, catchSearchQueries, supplierNotAllowed, validateSearchRequestUser, checkUserIdField, searchRequests);
 // eslint-disable-next-line max-len
-router.get('/manager/search', validateToken, catchSearchQueries, supplierNotAllowed, checkManagerRole, validateSearchRequestManager, managerUserIdField, searchRequests);
+router.get('/manager/search', validateToken, catchSearchQueries, supplierNotAllowed, checkManagerRole, validateSearchRequestManager, managerUserIdField, catchOriginDestination, searchRequests);
 router.get('/', validateToken, viewMyRequests);
 router.get('/manager', validateToken, checkManagerRole, viewManagerRequests);
 router.patch('/manager/:action/:id', validateToken, checkManagerRole, checkId, wrongAction, isProcessed, changeStatus);

--- a/src/tests/searchRequestsTests.spec.js
+++ b/src/tests/searchRequestsTests.spec.js
@@ -83,16 +83,6 @@ describe('Search Requests Tests', () => {
       });
   });
 
-  it('Should not return requests of users not assigned to the manager by sending 403 status code', done => {
-    chai.request(app)
-      .get('/api/v1/requests/manager/search?userId=3')
-      .set('Authorization', `Bearer ${anotherManagerToken}`)
-      .end((err, res) => {
-        res.should.have.property('status').eql(403);
-        done();
-      });
-  });
-
   it('Should not give access to non-Managers by returning 403', done => {
     chai.request(app)
       .get('/api/v1/requests/manager/search?userId=3')
@@ -109,6 +99,46 @@ describe('Search Requests Tests', () => {
       .set('Authorization', `Bearer ${managerToken}`)
       .end((err, res) => {
         res.should.have.property('status').eql(200);
+        done();
+      });
+  });
+
+  it('Should return requests that match username, 200 status code', done => {
+    chai.request(app)
+      .get('/api/v1/requests/manager/search?username=alain')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(200);
+        done();
+      });
+  });
+
+  it('Should return requests that match origin, 200 status code', done => {
+    chai.request(app)
+      .get('/api/v1/requests/manager/search?origin=kamp')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(200);
+        done();
+      });
+  });
+
+  it('Should return requests that match destination, 200 status code', done => {
+    chai.request(app)
+      .get('/api/v1/requests/manager/search?destination=lagos')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(200);
+        done();
+      });
+  });
+
+  it('Should not return requests that match username, 404 status code', done => {
+    chai.request(app)
+      .get('/api/v1/requests/manager/search?username=krinkun')
+      .set('Authorization', `Bearer ${managerToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(404);
         done();
       });
   });


### PR DESCRIPTION
### What does this PR do?
Modify Search Finctionality to search by `username, not userId` and `origin/destination with strings`.

#### Description of Task to be completed?
- Edit validationRequestSearch to search by username and origin/destination=string
- Create a middleware to search the locations ids matching the search queries
- Edit managerUserIdField to return the users matching the username in queries

#### How should this be manually tested?
- Clone the repository from [here](https://github.com/andela/caret-bn-backend.git)
- Browse to the repo directory
- navigate to ch-modify-search-169469778 branch
- Run `npm install`
- run `sequelize db:migrate`
- run `sequelize db:seed:all`
- run `npm run dev`

**To Search Requests**
* If you are logged in as a manager
Send a GET request to `http://localhost:port/api/v1/requests/manager/search?username=thomas&origin=kampala`
* If you are logged in as a requester
Send a GET request to `http://localhost:port/api/v1/requests/username=thomas&destination=lagos`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#169469778](https://www.pivotaltracker.com/story/show/169469778)

#### Screenshots (if appropriate)
<img width="1119" alt="Screen Shot 2019-11-03 at 21 11 40" src="https://user-images.githubusercontent.com/42959540/68092458-0db39a80-fe94-11e9-9267-f6177904ae5f.png">
<img width="1131" alt="Screen Shot 2019-11-03 at 23 44 30" src="https://user-images.githubusercontent.com/42959540/68092460-0f7d5e00-fe94-11e9-8176-6a10e713f0a0.png">

#### Questions:
N/A
