### PR TITLE
FT(Users Mark All Notifications): All users Mark Notifications

### DIFF
--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -8,12 +8,11 @@ const { NOTIF_NOT_FOUND, NOTIF_FOUND } = strings.notifications;
 export default class notificationController {
 
   static async allNotifications(req, res) {
-    const notifications = await allNotif(req.user.payload.id);
-
+    const query = { where: { userNotified: req.user.payload.id } };
+    const notifications = await allNotif(query);
     if (!notifications.length) {
       return responseUtil(res, 404, NOTIF_NOT_FOUND);
     }
-
     return responseUtil(res, 200, NOTIF_FOUND, notifications);
   }
 
@@ -28,14 +27,44 @@ export default class notificationController {
   }
 
   static async switchRead(req, res) {
-    const updatedNotif = await updateNotif(parseInt(req.params.id, 10), req.user.payload.id);
+    const { id } = req.params;
+    const userNotified = req.user.payload.id;
+    const query = {
+      where: {
+        id,
+        userNotified,
+      }
+    };
 
-    if (!updatedNotif) {
-      return responseUtil(res, 404, NOTIF_NOT_FOUND);
+    try {
+      const updatedNotif = await updateNotif(query);
+      const status = (updatedNotif.isRead) ? '' : 'un';
+      const message = `This notification status has been marked as ${status}read`;
+      return responseUtil(res, 200, message);
+    } catch (error) {
+      return responseUtil(res, 404, error.message);
     }
+  }
 
-    const status = (updatedNotif.isRead) ? '' : 'un';
-    const message = `This notification status has been marked as '${status}read'`;
-    return responseUtil(res, 200, message);
+  static async markAllRead(req, res) {
+    const { id } = req.user.payload;
+    const query = { where: { userNotified: id, isRead: false } };
+    const notifications = await notifServices.allNotif(query);
+    if (notifications.length === 0) {
+      return responseUtil(res, 409, 'You have no unread notifications');
+    }
+    Promise.all(notifications.map(async notification => {
+      await notification.update({
+        isRead: true
+      }).then(notification => {
+        try {
+          return notification.save();
+        } catch (error) {
+          return responseUtil(res, 500, 'Unable to complete', error.message);
+        }
+      });
+    }))
+      .then(() => responseUtil(res, 200, 'marked all notifications as read'))
+      .catch(error => responseUtil(res, 500, 'Unable to complete', error.message));
   }
 }

--- a/src/database/seeders/20191028170529-notificationsTableSeeder.js
+++ b/src/database/seeders/20191028170529-notificationsTableSeeder.js
@@ -27,7 +27,24 @@ module.exports = {
         createdAt: new Date(),
         updatedAt: new Date()
       },
-  ])
+      {
+        requestId: 2,
+        userNotified: 3,
+        activity: 'approved',
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        requestId: 2,
+        userNotified: 3,
+        activity: 'approved',
+        isRead: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+
+    ])
   ]),
 
   down: (queryInterface, Sequelize) => Promise.all([

--- a/src/routes/api/notifications.js
+++ b/src/routes/api/notifications.js
@@ -3,7 +3,9 @@ import notificationController from '../../controllers/notificationController';
 import validateToken from '../../middlewares/auth/validateToken';
 import checkId from '../../middlewares/checkId';
 
-const { allNotifications, oneNotification, switchRead } = notificationController;
+const {
+  allNotifications, oneNotification, switchRead, markAllRead
+} = notificationController;
 const router = express.Router();
 
 /**
@@ -78,9 +80,29 @@ const router = express.Router();
  *       '404':
  *         description: No Notification Found!
 */
-
+/**
+ * @swagger
+ * /notifications/mark/read/:
+ *   patch:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Notifications
+ *     name: Mark all notifications as read
+ *     summary: Mark all notifications as read
+ *     consumes:
+ *       - application/json
+ *     produces:
+ *       - application/json
+ *     responses:
+ *       '200':
+ *         description: marked all notifications as read
+ *       '404':
+ *         description: You have no unread notifications
+*/
 router.get('/', validateToken, allNotifications);
 router.get('/:id', validateToken, checkId, oneNotification);
 router.patch('/:id/mark', validateToken, checkId, switchRead);
+router.patch('/mark/read', validateToken, markAllRead);
 
 export default router;

--- a/src/services/notifServices.js
+++ b/src/services/notifServices.js
@@ -6,8 +6,8 @@ export default class notifServices {
     return notification;
   }
 
-  static async allNotif(userNotified) {
-    const notifications = await models.notifications.findAll({ where: { userNotified } });
+  static async allNotif(query) {
+    const notifications = await models.notifications.findAll(query);
     return notifications;
   }
 
@@ -21,25 +21,24 @@ export default class notifServices {
     return notification;
   }
 
-  static async updateNotif(id, userNotified) {
-    const findNotification = await models.notifications.findOne({
-      where: {
-        id,
-        userNotified,
-      }
-    });
+  static async updateNotif(query) {
+    const findNotification = await models.notifications.findOne(query);
 
     if (!findNotification) {
-      return null;
+      throw new Error('Notification Not Available');
     }
-
-    const updatedNotif = await models.notifications.update(
-      { isRead: !findNotification.isRead },
-      {
-        where: { id, userNotified }, returning: true, plain: true,
-      }
-    );
-    return updatedNotif[1].dataValues;
+    const whereClause = query.where;
+    try {
+      const updatedNotif = await models.notifications.update(
+        { isRead: !findNotification.isRead },
+        {
+          where: whereClause, returning: true, plain: true,
+        }
+      );
+      return updatedNotif[1];
+    } catch (error) {
+      throw new Error(`Something went wrong: ${error.message}`);
+    }
   }
 
   static async notifBuilder(request, userNotified, activity) {

--- a/src/tests/notificationsTests.spec.js
+++ b/src/tests/notificationsTests.spec.js
@@ -33,9 +33,9 @@ describe('Notifications Tests', () => {
     chai.request(app)
       .patch('/api/v1/notifications/3/mark')
       .set('Authorization', `Bearer ${userToken}`)
-      .end((err, res) => {        
+      .end((err, res) => {
         res.should.have.property('status').eql(200);
-        res.body.should.have.property('message').eql(`This notification status has been marked as 'read'`);
+        res.body.should.have.property('message').eql('This notification status has been marked as read');
         done();
       });
   });
@@ -46,7 +46,7 @@ describe('Notifications Tests', () => {
       .set('Authorization', `Bearer ${userToken}`)
       .end((err, res) => {
         res.should.have.property('status').eql(200);
-        res.body.should.have.property('message').eql(`This notification status has been marked as 'unread'`);
+        res.body.should.have.property('message').eql('This notification status has been marked as unread');
         done();
       });
   });
@@ -56,11 +56,12 @@ describe('Notifications Tests', () => {
     chai.request(app)
       .get('/api/v1/notifications/')
       .set('Authorization', `Bearer ${userToken}`)
-      .end((err, res) => {        
+      .end((err, res) => {
         res.should.have.property('status').eql(200);
         done();
       });
   });
+
 
   it('Should get one notification', done => {
     chai.request(app)
@@ -81,6 +82,29 @@ describe('Notifications Tests', () => {
         done();
       });
   });
+
+  it('Should mark all notifications as read', done => {
+    chai.request(app)
+      .patch('/api/v1/notifications/mark/read')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(200);
+        res.body.should.have.property('message').eql('marked all notifications as read');
+        done();
+      });
+  });
+
+  it('Should not mark all notifications as read twice', done => {
+    chai.request(app)
+      .patch('/api/v1/notifications/mark/read')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(409);
+        res.body.should.have.property('message').eql('You have no unread notifications');
+        done();
+      });
+  });
+
 
   // Acivate/Deactivate Email Notifications
   it('Should deactivate email notifications', done => {


### PR DESCRIPTION
#### What does this PR do?
Allows users to mark all their notification as read

#### Description of Task to be completed?
Enable an authenticated user to mark all their tasks as read.

#### How should this be manually tested?

1. Clone this repository
2. Run ` sequelize db:migrate `
3. Run ` sequelize db:seed:All `
4. Run ` npm run dev `
5. Log into the application at `api/v1/users/login`
6. Using an  authenticated user send a patch request to `api/v1/notifications/mark/read`

#### Any background context you want to provide?
N /A 
#### What are the relevant pivotal tracker stories?
##### #168781713

#### Screenshots (if appropriate)

<img width="1172" alt="Screen Shot 2019-11-04 at 17 06 41" src="https://user-images.githubusercontent.com/13886438/68131576-f4f3c500-ff25-11e9-9354-2da38b5ca5d1.png">
<img width="1258" alt="Screen Shot 2019-11-04 at 17 06 31" src="https://user-images.githubusercontent.com/13886438/68131575-f4f3c500-ff25-11e9-9ad1-755d71a9e174.png">
<img width="1044" alt="Screen Shot 2019-11-04 at 17 09 42" src="https://user-images.githubusercontent.com/13886438/68131578-f58c5b80-ff25-11e9-82c5-85bc06f0fc0f.png">
<img width="875" alt="Screen Shot 2019-11-04 at 17 09 46" src="https://user-images.githubusercontent.com/13886438/68131581-f624f200-ff25-11e9-996a-dd66abad0ef9.png">


#### Questions:

N / A
