### PR TITLE
#168781712 -  get stats of trips made in the last X timeframe

### DIFF
--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -13,6 +13,7 @@ import searchRequestsServices from '../services/searchRequestsServices';
 import Utilities from '../utils/index';
 import findOneRequest from '../helpers/findOneRequest';
 import findUser from '../helpers/findUser';
+import requestHelper from '../helpers/requestHelper';
 import notifSender from '../helpers/notifSender';
 
 const { Op } = Sequelize;
@@ -146,4 +147,11 @@ export default class requestController {
     const request = await createRequest(body, user.payload.id);
     return destinationController.storeDestination(req, res, body, user, request);
   }
+
+  static async getStats(req, res) {
+    const requestResults = await requestHelper.findStatRequest(req, res);
+    return responseUtil(res, 200, strings.request.success.RESULT, requestResults.count);
+
+  }
+
 }

--- a/src/helpers/checkDateHelper.js
+++ b/src/helpers/checkDateHelper.js
@@ -11,4 +11,6 @@ const checkDate = (res, startDate, endDate) => {
     responseUtil(res, 400, strings.accommodation.error.DATE_ERROR);
   }
 };
+
+
 export default checkDate;

--- a/src/helpers/requestHelper.js
+++ b/src/helpers/requestHelper.js
@@ -1,5 +1,8 @@
+import sequelize from 'sequelize';
 import models from '../database/models';
-
+import dateValidator from './datesValidator';
+import responseUtil from '../utils/responseUtil';
+import strings from '../utils/stringsUtil';
 
 const findOneRequest = properties => {
   const request = models.requests.findOne({
@@ -9,4 +12,23 @@ const findOneRequest = properties => {
   return request;
 };
 
-export default { findOneRequest };
+const findStatRequest = async (req, res) => {
+  const { startDate, endDate } = req.query;
+  const { Op } = sequelize;
+  const checkDate = dateValidator(startDate, endDate);
+  if (checkDate === true) {
+    responseUtil(res, 400, strings.request.error.DATE_ERROR);
+  }
+  const requestResult = await models.requests.findAndCountAll({
+    where: {
+      userId: req.user.payload.id,
+      statusId: 3,
+      departureDate: {
+        [Op.between]: [startDate, endDate],
+      }
+    }
+  });
+  return requestResult;
+};
+
+export default { findOneRequest, findStatRequest };

--- a/src/middlewares/inputValidation.js
+++ b/src/middlewares/inputValidation.js
@@ -221,4 +221,12 @@ export default class InputValidation {
     validation(req, res, schema, next);
   }
 
+  static validateRequestStas(req, res, next) {
+    const schema = Joi.object().keys({
+      startDate: Joi.string().regex(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/).message('startDate format must be YYYY-MM-DD').required(),
+      endDate: Joi.string().regex(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/).message('endDate format must be YYYY-MM-DD').required(),
+    });
+    validation(req, res, schema, next);
+  }
+
 }

--- a/src/routes/api/requests.js
+++ b/src/routes/api/requests.js
@@ -16,12 +16,13 @@ import catchOriginDestination from '../../middlewares/catchOriginDestination';
 
 const router = new Router();
 const {
-  viewMyRequests, changeStatus, viewManagerRequests, searchRequests, updateRequest
+  viewMyRequests, changeStatus, viewManagerRequests, searchRequests, updateRequest,
+  getStats,
 } = requestController;
 
 const {
   validateSearchRequestUser, validateSearchRequestManager,
-  validateComment, validateRequest,
+  validateComment, validateRequest, validateRequestStas
 } = InputValidation;
 const { checkManagerRole, supplierNotAllowed } = checkRole;
 const { editComment, deleteComment } = commentsController;
@@ -156,4 +157,6 @@ router.patch('/manager/:action/:id', validateToken, checkManagerRole, checkId, w
 router.patch('/:id', validateToken, pendingRequest.requestOwner, pendingRequest.selectPending, validateRequest, pendingRequest.validateBody, updateRequest);
 router.put('/comments/:id', validateToken, checkId, validateComment, editComment);
 router.delete('/comments/:id', validateToken, checkId, deleteComment);
+router.get('/stats/', validateToken, supplierNotAllowed, catchSearchQueries, validateRequestStas, getStats);
+router.get('/:id', (req, res) => requestController.findOne(req, res));
 export default router;

--- a/src/tests/RequestStats.spec.js
+++ b/src/tests/RequestStats.spec.js
@@ -1,0 +1,72 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { describe, it, before } from 'mocha';
+import app from '../index';
+import mockData from './mockData/mockData';
+
+chai.should();
+chai.use(chaiHttp);
+
+let userToken;
+let supplierToken;
+
+describe('stats Requests Tests', () => {
+  before(done => {
+    chai.request(app)
+      .post('/api/v1/users/login')
+      .send(mockData.registeredUser)
+      .end((err, res) => {
+        userToken = res.body.data.token;
+      });
+    chai.request(app)
+      .post('/api/v1/users/login')
+      .send(mockData.supplier)
+      .end((err, res) => {
+        supplierToken = res.body.data.token;
+        done();
+      });
+  });
+
+
+  it('Should return stats ', done => {
+    chai.request(app)
+      .get('/api/v1/requests/stats?startDate=2019-03-03&endDate=2019-11-07')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(200);
+        res.body.should.have.property('message').eql('Your number of trips are:');
+        done();
+      });
+  });
+
+  it('Should return stats with invalid date', done => {
+    chai.request(app)
+      .get('/api/v1/requests/stats?startDate=2019-12-07&endDate=2019-11-03')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(400);
+        res.body.should.have.property('message').eql('startDate  must not be greater than endDate');
+        done();
+      });
+  });
+  
+  it('Should return 403 status, Supplier not allowed', done => {
+    chai.request(app)
+      .get('/api/v1/requests/stats?startDate=2019-03-03&endDate=2019-11-07')
+      .set('Authorization', `Bearer ${supplierToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(403);
+        done();
+      });
+  });
+
+  it('Should return 400 status, with invalid input', done => {
+    chai.request(app)
+      .get('/api/v1/requests/stats?days=-23')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        res.should.have.property('status').eql(400);
+        done();
+      });
+  });
+});

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -15,6 +15,7 @@ import ratingsTest from './ratingsTests.spec';
 import commentsTests from './comment.spec';
 import destinationTests from './destinationTests.spec';
 import chatTests from './chatTests.spec';
+import RequestStats from './RequestStats.spec'
 
 describe('Default Tests', defaultTests);
 describe('Edit Request Tests', editRequest);
@@ -37,4 +38,5 @@ describe('Ratings Tests', ratingsTest);
 describe('Comments Tests', commentsTests);
 describe('Destination Tests', destinationTests);
 describe('Chat Tests', chatTests);
+describe('RequestStats Tests', RequestStats);
 

--- a/src/utils/stringsUtil.js
+++ b/src/utils/stringsUtil.js
@@ -45,8 +45,11 @@ const strings = {
     success: {
       SUCCESS_UPDATE_REQUEST: 'Request Updated',
       SUCCESS_ADD_COMMENT: 'Comment Added',
+      RESULT: 'Your number of trips are:',
     },
+
     error: {
+      DATE_ERROR: 'startDate  must not be greater than endDate',
       INTERNAL_ERROR: 'Internal server error',
       NO_REQUEST_REQUEST: 'This Id request does not exist',
       EDIT_YOUR_REQUEST: 'Access denied! you are not the owner of this request',


### PR DESCRIPTION
#### What does this PR do?
PR to allow user to get stats of trips made in the last X timeframe
#### Description of Task to be completed?
- add getRequestStats function
- add findStatRequest helper
#### How should this be manually tested?
- clone the repository : git clone https://github.com/andela/caret-bn-backend.git
- checkout to branch ft-get-stats-trips-168781712
- run sequelize db:migrate
- run sequelize db:seed:all
- use this route to get  your  trips stast  by Dates`GET :/api/v1/requests/stats?startDate=&endDate=`
#### Any background context you want to provide?
`N/A`
#### What are the relevant pivotal tracker stories?
[#168781712](https://www.pivotaltracker.com/story/show/168781712)
#### Screenshots (if appropriate)
<img width="1028" alt="Screen Shot 2019-11-08 at 12 06 48" src="https://user-images.githubusercontent.com/47029978/68468231-4fd83580-0220-11ea-9b2d-6dd45ca3f0ad.png">


#### Questions:
`N/A`