### PR TITLE
#169622495 - Hotfix Fixing a bug on Requests Search for the User routes

### DIFF
--- a/src/routes/api/requests.js
+++ b/src/routes/api/requests.js
@@ -147,7 +147,7 @@ const { editComment, deleteComment } = commentsController;
 router.use(validateToken);
 
 router.post('/', verifyRelationships, (req, res) => requestController.storeRequest(req, res));
-router.get('/search', validateToken, catchSearchQueries, supplierNotAllowed, validateSearchRequestUser, checkUserIdField, searchRequests);
+router.get('/search', validateToken, catchSearchQueries, supplierNotAllowed, validateSearchRequestUser, checkUserIdField, catchOriginDestination, searchRequests);
 // eslint-disable-next-line max-len
 router.get('/manager/search', validateToken, catchSearchQueries, supplierNotAllowed, checkManagerRole, validateSearchRequestManager, managerUserIdField, catchOriginDestination, searchRequests);
 router.get('/', validateToken, viewMyRequests);


### PR DESCRIPTION
#### What does this PR do?
Hotfix Fixing a bug on Requests Search for the User routes.

#### Description of Task to be completed?
- Add catchOriginDestination middleware to the route.

#### How should this be manually tested?
- Clone the repository from [here](https://github.com/andela/caret-bn-backend.git)
- Browse to the repo directory
- navigate to bg-hotfix-search-requests-169622495 branch
- Run `npm install`
- run `sequelize db:migrate`
- run `sequelize db:seed:all`
- run `npm run dev`

**To Search Requests**
* If you are logged in as a requester
Send a GET request to `http://localhost:port/api/v1/requests/destination=lagos`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#169622495](https://www.pivotaltracker.com/story/show/169622495)

#### Screenshots (if appropriate)
<img width="1120" alt="Screen Shot 2019-11-07 at 15 52 41" src="https://user-images.githubusercontent.com/42959540/68395613-bace3180-0178-11ea-9d6b-401af9edf24b.png">

#### Questions:
N/A
