### PR TITLE
#169649132 view past stats

### DIFF
--- a/src/tests/RequestStats.spec.js
+++ b/src/tests/RequestStats.spec.js
@@ -9,6 +9,7 @@ chai.use(chaiHttp);
 
 let userToken;
 let supplierToken;
+let requesterToken; 
 
 describe('stats Requests Tests', () => {
   before(done => {
@@ -23,6 +24,12 @@ describe('stats Requests Tests', () => {
       .send(mockData.supplier)
       .end((err, res) => {
         supplierToken = res.body.data.token;
+      });
+      chai.request(app)
+      .post('/api/v1/users/login')
+      .send(mockData.requester)
+      .end((err, res) => {
+        requesterToken = res.body.data.token;
         done();
       });
   });
@@ -33,6 +40,8 @@ describe('stats Requests Tests', () => {
       .get('/api/v1/requests/stats?startDate=2019-03-03&endDate=2019-11-07')
       .set('Authorization', `Bearer ${userToken}`)
       .end((err, res) => {
+        console.log(res.body);
+        
         res.should.have.property('status').eql(200);
         res.body.should.have.property('message').eql('Your number of trips are:');
         done();
@@ -46,6 +55,19 @@ describe('stats Requests Tests', () => {
       .end((err, res) => {
         res.should.have.property('status').eql(400);
         res.body.should.have.property('message').eql('startDate  must not be greater than endDate');
+        done();
+      });
+  });
+
+  it('Should tell the user that Either startDate or endDate must not be greater than today\'s date', done => {
+    chai.request(app)
+      .get('/api/v1/requests/stats?startDate=2019-12-07&endDate=2020-11-03')
+      .set('Authorization', `Bearer ${userToken}`)
+      .end((err, res) => {
+        console.log(res.body);
+        
+        res.should.have.property('status').eql(400);
+        res.body.should.have.property('message').eql('Either startDate or endDate must not be greater than today\'s date');
         done();
       });
   });
@@ -66,6 +88,18 @@ describe('stats Requests Tests', () => {
       .set('Authorization', `Bearer ${userToken}`)
       .end((err, res) => {
         res.should.have.property('status').eql(400);
+        done();
+      });
+  });
+
+  it('Should tell the user that they have no trips', done => {
+    chai.request(app)
+      .get('/api/v1/requests/stats?startDate=2019-01-07&endDate=2019-11-12')
+      .set('Authorization', `Bearer ${requesterToken}`)
+      .end((err, res) => {
+        console.log(res.body);
+        
+        res.should.have.property('status').eql(200);
         done();
       });
   });

--- a/src/utils/stringsUtil.js
+++ b/src/utils/stringsUtil.js
@@ -60,6 +60,7 @@ const strings = {
       TRAVEL_ADMINS_ONLY: 'Access denied! Only travel administrators can access this part of the system!',
       NOT_YOUR_REQUEST: 'You are not the owner of the request or the line manager of the user who placed it!',
       NO_LOCATION: 'Location does not exist on the system!',
+      OUT_OF_BOUND: 'Either startDate or endDate must not be greater than today\'s date',
     },
   },
   token: {


### PR DESCRIPTION
#### What does this PR do?
View trip stats in the past X timeframe

#### Description of Task to be completed?
-  adding the possibility to view the number of trips from the past X timeframe as well as the actual trips

#### How should this be manually tested?
- clone the repository : git clone https://github.com/andela/caret-bn-backend.git
- checkout to branch ch-view-past-stats-169649132
- run sequelize db:migrate
- run sequelize db:seed:all
- use this route to get  your  trips stast  by Dates`GET :/api/v1/requests/stats?startDate=&endDate=`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#169649132

#### Screenshots (if appropriate)
<img width="1167" alt="Screen Shot 2019-11-13 at 11 42 26" src="https://user-images.githubusercontent.com/50104386/68751705-b6879580-060a-11ea-954d-95f9769f1b9b.png">
<img width="1167" alt="Screen Shot 2019-11-12 at 16 21 42" src="https://user-images.githubusercontent.com/50104386/68679455-92737800-0568-11ea-898c-7497763e27e7.png">


#### Questions:
N/A