### PR TITLE
#169749860 - Add timestamp field to notifications

### DIFF
--- a/src/controllers/commentsController.js
+++ b/src/controllers/commentsController.js
@@ -26,7 +26,7 @@ export default class CommentsController {
       const notification = await notifBuilder(
         request,
         userNotiified,
-        `A comment has been made on request ${requestId}. Click here to view: ${APP_URL_BACKEND}/api/v1/requests/${requestId}.`
+        `A comment has been made on request ${requestId}. Click here to view: ${APP_URL_BACKEND}/api/v1/requests/${requestId}.`,
       );
       await notifSaver(notification);
       const {

--- a/src/database/migrations/20191113182004-addTimeNotification.js
+++ b/src/database/migrations/20191113182004-addTimeNotification.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(t => Promise.all([
+    queryInterface.addColumn('notifications', 'timestamp', {
+      type: Sequelize.TIME,
+    }, { transaction: t }),
+    queryInterface.addColumn('bookingNotifications', 'timestamp', {
+      type: Sequelize.TIME,
+    }, { transaction: t }),
+  ])),
+
+  down: queryInterface => queryInterface.sequelize.transaction(t => Promise.all([
+    queryInterface.removeColumn('notifications', 'timestamp', { transaction: t }),
+    queryInterface.removeColumn('bookingNotifications', 'timestamp', { transaction: t }),
+  ])),
+};

--- a/src/database/models/bookingnotifications.js
+++ b/src/database/models/bookingnotifications.js
@@ -1,3 +1,4 @@
+
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const bookingNotifications = sequelize.define('bookingNotifications', {
@@ -7,6 +8,9 @@ module.exports = (sequelize, DataTypes) => {
     isRead: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
+    },
+    timestamp: {
+      type: DataTypes.TIME,
     },
   }, {
     tableName: 'bookingNotifications'

--- a/src/database/models/notifications.js
+++ b/src/database/models/notifications.js
@@ -1,9 +1,13 @@
+
 'use strict';
 module.exports = (sequelize, DataTypes) => {
   const notifications = sequelize.define('notifications', {
     requestId: DataTypes.INTEGER,
     userNotified: DataTypes.INTEGER,
     activity: DataTypes.STRING,
+    timestamp: {
+      type: DataTypes.TIME,
+    },
     isRead: {
       type: DataTypes.BOOLEAN,
       defaultValue: false,

--- a/src/database/seeders/20191028170529-notificationsTableSeeder.js
+++ b/src/database/seeders/20191028170529-notificationsTableSeeder.js
@@ -6,42 +6,47 @@ module.exports = {
       {
         requestId: 2,
         userNotified: 8,
-        activity: 'created',
+        activity: 'A request has been created. Click here to view: https://caret-bn-backend-staging.herokuapp.com/api/v1/requests/2.',
         isRead: false,
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
+        timestamp: new Date()
       },
       {
         requestId: 2,
         userNotified: 3,
-        activity: 'rejected',
+        activity: 'A request has been rejected. Click here to view: https://caret-bn-backend-staging.herokuapp.com/api/v1/requests/2.',
         isRead: true,
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
+        timestamp: new Date()
       },
       {
         requestId: 2,
         userNotified: 3,
-        activity: 'approved',
+        activity: 'A request has been approved. Click here to view: https://caret-bn-backend-staging.herokuapp.com/api/v1/requests/2.',
         isRead: false,
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
+        timestamp: new Date()
       },
       {
         requestId: 2,
         userNotified: 3,
-        activity: 'approved',
+        activity: 'A request has been approved. Click here to view: https://caret-bn-backend-staging.herokuapp.com/api/v1/requests/2.',
         isRead: false,
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
+        timestamp: new Date()
       },
       {
         requestId: 2,
         userNotified: 3,
-        activity: 'approved',
+        activity: 'A request has been approved. Click here to view: https://caret-bn-backend-staging.herokuapp.com/api/v1/requests/2.',
         isRead: false,
         createdAt: new Date(),
-        updatedAt: new Date()
+        updatedAt: new Date(),
+        timestamp: new Date()
       },
 
     ])

--- a/src/services/bookingNotifServices.js
+++ b/src/services/bookingNotifServices.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import models from '../database/models';
 
 export default class bookingNotifServices {
@@ -22,10 +23,12 @@ export default class bookingNotifServices {
   }
 
   static async bookingNotifBuilder(booking, userNotified, activity) {
+    const timestamp = moment().format('HH:mm:ss');
     const notification = await models.bookingNotifications.build({
       bookingId: booking.id,
       userNotified,
       activity,
+      timestamp,
     });
     return notification;
   }

--- a/src/services/notifServices.js
+++ b/src/services/notifServices.js
@@ -1,4 +1,5 @@
 /* eslint-disable  require-jsdoc */
+import moment from 'moment';
 import models from '../database/models';
 
 export default class notifServices {
@@ -43,10 +44,12 @@ export default class notifServices {
   }
 
   static async notifBuilder(request, userNotified, activity) {
+    const timestamp = moment().format('HH:mm:ss');
     const notification = await models.notifications.build({
       requestId: request.id,
       userNotified,
       activity,
+      timestamp,
     });
     return notification;
   }

--- a/src/utils/db/queries/notificationQueries.js
+++ b/src/utils/db/queries/notificationQueries.js
@@ -8,7 +8,7 @@ export const userNotidicationQuery = userId => {
           userNotified: userId
         },
     attributes: [
-      'id', 'activity', 'isRead', 'createdAt', 'updatedAt'
+      'id', 'activity', 'isRead', 'createdAt', 'timestamp', 'updatedAt'
     ],
     include: [
       {


### PR DESCRIPTION
#### What does this PR do?
Add a `timestamp` field to `Notifications`.

#### Description of Task to be completed?
- Create migration file to add a `timestamp` to notifications tables
- Add moment to models to save the current time to the notification

#### How should this be manually tested?
- Clone the repository from [here](https://github.com/andela/caret-bn-backend.git)
- Browse to the repo directory
- navigate to ch-notifications-timestamp-169749860 branch
- Run `npm install`
- run `sequelize db:migrate`
- run `sequelize db:seed:all`
- run `npm run dev`

- To view notifications
Send a GET request to http://localhost:port/api/v1/notifications
Send a GET request to http://localhost:port/api/v1/notifications/notificationId

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#169749860](https://www.pivotaltracker.com/story/show/169749860)

#### Screenshots (if appropriate)
<img width="1137" alt="Screen Shot 2019-11-14 at 10 26 11" src="https://user-images.githubusercontent.com/42959540/68841121-b059ed80-06cc-11ea-8fd6-bfe7edd5e649.png">

#### Questions:
N/A
