### PR TITLE
#169757876 - Add likes/unlikes on get all accommodations

### DIFF
--- a/src/database/models/accommodations.js
+++ b/src/database/models/accommodations.js
@@ -38,7 +38,7 @@ module.exports = (sequelize, DataTypes) => {
     accommodations.hasMany(models.likes, {
       targetKey: "accommodationId",
       sourceKey: "id",
-      as: "accomodationLike"
+      as: "likes"
     });
   };
   return accommodations;

--- a/src/helpers/ratingsHelper.js
+++ b/src/helpers/ratingsHelper.js
@@ -6,14 +6,25 @@ export const getRatings = async (accommodation, userId) => {
     if (accommodation) {
         const ratings = await accommodation.getRatings();
         const bookmarks = await accommodation.getBookmarks();
+        const likes = await accommodation.getLikes({ where: { status: true } });
+        const unlikes = await accommodation.getLikes({ where: { status: false } });
+        const Likes = likes.length;
+        const Unlikes = unlikes.length;
         const hasRated = ratings.some(rating => rating.userId === userId);
         const hasBookmarked = bookmarks.some(bookmark => bookmark.userId === userId);
+        const hasLiked = likes.some(like => like.userId === userId);
+        const hasUnliked = unlikes.some(unlike => unlike.userId === userId);
         const summation = await ratings.reduce((averageValue, cuurentValue) => averageValue + cuurentValue.rating, 0);
         const averageRating = summation / ratings.length;
         accommodation.dataValues.hasRated = hasRated;
         accommodation.dataValues.hasBookmarked = hasBookmarked;
         accommodation.dataValues.averageRating = averageRating;
         accommodation.dataValues.ratings = ratings;
+
+        accommodation.dataValues.Likes = Likes;
+        accommodation.dataValues.Unlikes = Unlikes;
+        accommodation.dataValues.hasLiked = hasLiked;
+        accommodation.dataValues.hasUnliked = hasUnliked;
     }
 
     return accommodation;

--- a/src/middlewares/isAccommodationExist.js
+++ b/src/middlewares/isAccommodationExist.js
@@ -3,27 +3,21 @@ import responseError from '../utils/responseError';
 
 const isAccommodationExist = {
   async accommodationExist(req, res, next) {
-    const { id, slug } = req.params;
-    let idAccommodation;
-    let condition;
-    if (!id) {
-      condition = slug;
-      idAccommodation = await models.accommodations.findOne({
-        where: { slug }
-      });
-    } else {
-      condition = id;
-      idAccommodation = await models.accommodations.findOne({
-        where: { id }
-      });
-    }
+    const { slug } = req.params;
+    const idAccommodation = await models.accommodations.findOne({
+      where: { slug }
+    });
 
     if (!idAccommodation) {
-      return responseError(
-        res,
-        404,
-        `Accommodation ${condition} does not exist`
-      );
+      return responseError(res, 404, `Accommodation ${slug} does not exist`);
+    }
+    return next();
+  },
+
+  checkAction(req, res, next) {
+    const { like } = req.params;
+    if (!(like === 'like' || like === 'unlike')) {
+      return responseError(res, 404, `Action '${like}' does not exist! Use 'like' or 'unlike'.`);
     }
     return next();
   }

--- a/src/routes/api/accommodations.js
+++ b/src/routes/api/accommodations.js
@@ -333,7 +333,7 @@ router.patch('/activate/:slug', validateToken, validateReasons, accommodationAct
 router.get('/admin/deactivated', validateToken, viewDeactivated);
 router.patch('/bookings/:action/:id', validateToken, checkSupplierRole, checkId, wrongAction, bookingFound, bookingNotPending, changeStatus);
 router.get('/bookings/:id', validateToken, checkId, viewOneBooking);
-router.post('/:id/:like', validateToken, checkId, supplierNotAllowed, accommodation.accommodationExist, likeAccommodation);
 router.get('/ratings/top-rated', validateToken, viewTopRated);
+router.post('/:slug/:like', validateToken, accommodation.checkAction, supplierNotAllowed, likeAccommodation);
 
 export default router;

--- a/src/services/likesServices/likesServices.js
+++ b/src/services/likesServices/likesServices.js
@@ -1,7 +1,4 @@
 import models from '../../database/models';
-import getAccommodation from '../../helpers/getAccommodation';
-
-const { getOneAccommodation } = getAccommodation;
 
 class LikeService {
   static async findLikes(accommodation, userId) {
@@ -10,19 +7,6 @@ class LikeService {
     });
     if (!like) return null;
     return like.dataValues;
-  }
-
-  static async hasliked(slug, userId, status) {
-    const accomodation = await models.accommodations.findOne({
-      where: { slug }
-    });
-    const liked = await models.likes.findOne({
-      where: { accommodationId: accomodation.id, userId, status }
-    });
-    // eslint-disable-next-line no-unneeded-ternary
-    const newLiked = (liked) ? liked : {};
-    newLiked.status = (liked !== null);
-    return newLiked.status;
   }
 
   static async addNewLike(like) {
@@ -36,13 +20,6 @@ class LikeService {
             { accommodationId: accommodation, userId }
     });
     return status;
-  }
-
-  static async likesSum(slug, id, status) {
-    const accommodation = await getOneAccommodation({ slug }, id);
-    const accommodationId = accommodation.id;
-    const likes = await models.likes.count({ where: { accommodationId, status } });
-    return likes;
   }
 }
 export default LikeService;

--- a/src/tests/likeTests.spec.js
+++ b/src/tests/likeTests.spec.js
@@ -10,11 +10,11 @@ chai.use(chaiHttp);
 
 let userToken;
 
-let id = 2;
-let id1 = 4;
+let slug = 'marriot';
+let slug1 = 'el-gorillaz';
 
 describe('Like and Unlike Accommodation Test', () => {
-    it('it should log in a supplier User', done => {
+    it('it should log in a User', done => {
       chai.request(app)
       .post('/api/v1/users/login')
       .send(mockData.verifiedUser4)
@@ -25,16 +25,25 @@ describe('Like and Unlike Accommodation Test', () => {
     });
     it('it should create a new like', done => {
         chai.request(app)
-        .post(`/api/v1/accommodations/${id}/like`)
+        .post(`/api/v1/accommodations/${slug}/like`)
           .set('Authorization', `Bearer ${userToken}`)
           .end((err, res) => {
             res.should.have.status(201);
             done();
           });
       });
+      it('Action should like or unlike like', done => {
+        chai.request(app)
+        .post(`/api/v1/accommodations/${slug}/likebb`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .end((err, res) => {
+            res.should.have.status(404);
+            done();
+          });
+      });
       it('it should create a new unlike', done => {
         chai.request(app)
-        .post(`/api/v1/accommodations/${id1}/unlike`)
+        .post(`/api/v1/accommodations/${slug1}/unlike`)
           .set('Authorization', `Bearer ${userToken}`)
           .end((err, res) => {
             res.should.have.status(201);
@@ -43,7 +52,7 @@ describe('Like and Unlike Accommodation Test', () => {
       });
       it('it should dislike accommodation', done => {
         chai.request(app)
-        .post(`/api/v1/accommodations/${id}/unlike`)
+        .post(`/api/v1/accommodations/${slug}/unlike`)
           .set('Authorization', `Bearer ${userToken}`)
           .end((err, res) => {
             res.should.have.status(200);
@@ -52,7 +61,7 @@ describe('Like and Unlike Accommodation Test', () => {
       });
       it('it should like back', done => {
         chai.request(app)
-        .post(`/api/v1/accommodations/${id}/like`)
+        .post(`/api/v1/accommodations/${slug}/like`)
           .set('Authorization', `Bearer ${userToken}`)
           .end((err, res) => {
             res.should.have.status(200);
@@ -68,13 +77,4 @@ describe('Like and Unlike Accommodation Test', () => {
             done();
           });
         });
-        it('it should not like when ID is not integer', done => {
-            chai.request(app)
-            .post('/api/v1/accommodations/id/like')
-              .set('Authorization', `Bearer ${userToken}`)
-              .end((err, res) => {
-                res.should.have.status(400);
-                done();
-              });
-          });
 });


### PR DESCRIPTION
#### What does this PR do?
Add likes/unlikes on `getAllAccommodation` endpoint

#### Description of Task to be completed?
- Display like/unlike on getAllAccommodation
- Use a slag on creating like/unlike
#### How should this be manually tested?
- Browse to the repo directory
- navigate to ch-display-likes-accommodations-169757876
- Run `npm install`
- run `sequelize db:migrate`
- run `sequelize db:seed:all`
- run `npm run dev`

- To view all accommodation
Send a GET request to http://localhost:port/api/v1/accommodations/

- To like accommodation 
Send a POST request to http://localhost:port/api/v1/accommodations/:slug/:action 
- action must be like/unlike

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
 [#169757876](https://www.pivotaltracker.com/story/show/169757876)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/38130305/68925439-b8c52d80-078b-11ea-8c2e-008361565f8d.png)
![image](https://user-images.githubusercontent.com/38130305/68925556-e7db9f00-078b-11ea-94a7-a91cffcc03d2.png)

#### Questions:
N/A