### PR TITLE
#170255095 : CH - User views locations

### DIFF
--- a/src/controllers/locationsController.js
+++ b/src/controllers/locationsController.js
@@ -1,0 +1,18 @@
+/* eslint-disable indent */
+/* eslint-disable max-len */
+import { getLocations } from '../services/locationServices';
+import utilities from '../utils/index';
+
+export default class LocationsController {
+
+    static async viewLocations(req, res) {
+        const locations = await getLocations();
+        return utilities.responseHelper(
+            res,
+            'locations',
+            locations,
+            200
+        );
+    }
+
+}

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -11,6 +11,7 @@ import ratingRoutes from './ratings';
 import destinationRoutes from './destinations';
 import chatRoutes from './chats';
 import bookmarksRoutes from './bookmarks';
+import locationRoutes from './locations';
 
 const router = new Router();
 router.use('/auth', authRoutes);
@@ -25,5 +26,6 @@ router.use('/api-docs', swaggerRoute);
 router.use('/destinations', destinationRoutes);
 router.use('/chats', chatRoutes);
 router.use('/bookmarks', bookmarksRoutes);
+router.use('/locations', locationRoutes);
 
 export default router;

--- a/src/routes/api/locations.js
+++ b/src/routes/api/locations.js
@@ -1,0 +1,11 @@
+import Router from 'express';
+import locationsController from '../../controllers/locationsController';
+import validateToken from '../../middlewares/auth/validateToken';
+
+const router = new Router();
+
+router.use(validateToken);
+
+router.get('/', (req, res) => locationsController.viewLocations(req, res));
+
+export default router;

--- a/src/services/locationServices.js
+++ b/src/services/locationServices.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import models from '../database/models/index';
+
+export const getLocations = query => models.locations.findAll(query).then(locations => locations);

--- a/src/tests/locationTests.spec.js
+++ b/src/tests/locationTests.spec.js
@@ -1,0 +1,34 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { describe, it } from 'mocha';
+import app from '../index';
+import mockData from './mockData/mockData';
+
+chai.should();
+chai.use(chaiHttp);
+
+let userToken;
+
+
+describe('Like and Unlike Accommodation Test', () => {
+    it('it should log in a User', done => {
+        chai.request(app)
+            .post('/api/v1/users/login')
+            .send(mockData.verifiedUser4)
+            .end((err, res) => {
+                userToken = res.body.data.token;
+                done();
+            });
+    });
+
+
+    it('it should get all locations', done => {
+        chai.request(app)
+            .post(`/api/v1/locations`)
+            .set('Authorization', `Bearer ${userToken}`)
+            .end((err, res) => {
+                res.should.have.status(200);
+                done();
+            });
+    });
+});


### PR DESCRIPTION
#### What does this PR do?
- Enables a user to view all locations 

#### Description of Task to be completed?
- Allow an authenticated user to view all locations on barefoot nomad

#### How should this be manually tested?
1. Clone this repo
2. Run `npm install`
3. Run `npm run dev`
4. Log into the application using a user
5. Access the `GET` route `api/v1/locations`

#### Any background context you want to provide?
- Users in the front end must be able to view locations in order to place a request

#### What are the relevant pivotal tracker stories?
#170255095
#### Screenshots (if appropriate)
<img width="1163" alt="Screen Shot 2019-12-12 at 09 21 01" src="https://user-images.githubusercontent.com/13886438/70691124-010b3900-1cc1-11ea-8523-16733776b122.png">

#### Questions:
