### PR TITLE
170578497 - Fix notifications timestamp

### DIFF
--- a/src/database/migrations/20200108103838-changeDateType.js
+++ b/src/database/migrations/20200108103838-changeDateType.js
@@ -1,0 +1,23 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(t => Promise.all([
+    queryInterface.removeColumn('notifications', 'createdAt', { transaction: t }),
+    queryInterface.removeColumn('notifications', 'updatedAt', { transaction: t }),
+    queryInterface.addColumn('notifications', 'createdAt', {
+      type: Sequelize.DATE,
+    }, { transaction: t }),
+    queryInterface.addColumn('notifications', 'updatedAt', {
+      type: Sequelize.DATE,
+    }, { transaction: t }),
+  ])),
+
+  down: (queryInterface, Sequelize) => queryInterface.sequelize.transaction(t => Promise.all([
+    queryInterface.removeColumn('notifications', 'createdAt', { transaction: t }),
+    queryInterface.removeColumn('notifications', 'updatedAt', { transaction: t }),
+    queryInterface.addColumn('notifications', 'createdAt', {
+      type: Sequelize.DATEONLY,
+    }, { transaction: t }),
+    queryInterface.addColumn('notifications', 'updatedAt', {
+      type: Sequelize.DATEONLY,
+    }, { transaction: t }),
+  ])),
+};

--- a/src/middlewares/inputValidation.js
+++ b/src/middlewares/inputValidation.js
@@ -32,11 +32,11 @@ export default class InputValidation {
 
   static validateAddNew(req, res, next) {
     const schema = Joi.object({
-      name: Joi.string().trim().min(10).max(100)
+      name: Joi.string().trim()
         .message('Name should be at least 10 character and not more than 100 characters!')
         .required(),
-      description: Joi.string().min(10).max(250).required(),
-      locationId: Joi.number().integer().min(1).max(20)
+      description: Joi.string().required(),
+      locationId: Joi.number().integer().min(1)
         .required(),
       availableSpace: Joi.number().integer().min(1)
         .required(),
@@ -44,8 +44,8 @@ export default class InputValidation {
         .required(),
       currency: Joi.string().regex(/^(rwf|RWF|ksh|KSH|ugx|UGX|usd|USD)/).message('Currency should only be RWF, KSH, UGX or USD!')
         .required(),
-      highlights: Joi.string().min(10).max(250).required(),
-      amenities: Joi.string().min(10).max(250).required()
+      highlights: Joi.string().required(),
+      amenities: Joi.string().required()
     });
     validation(req, res, schema, next);
   }


### PR DESCRIPTION
#### What does this PR do?
Fix notifications timestamp

#### Description of Task to be completed?
- Add new migration file to change createdAt data-type to DATE.
- Remove length validation in `validateAddNew` (create accommodation).

#### How should this be manually tested?
- Clone the repository from [here](https://github.com/andela/caret-bn-backend.git)
- Browse to the repo directory
- Navigate to fix-time-notifications-170578497 branch
- Run `npm install`
- Run `sequelize db:migrate`
- Run `sequelize db:seed:all`
- Run `npm run dev`

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#170578497](https://www.pivotaltracker.com/story/show/170578497)

#### Screenshots (if appropriate)
<img width="755" alt="Screen Shot 2020-01-08 at 13 24 18" src="https://user-images.githubusercontent.com/42959540/71974495-47997800-321a-11ea-80a6-bd6903eaf0ba.png">

#### Questions:
N/A
